### PR TITLE
Remove type signatures with undefined variables

### DIFF
--- a/src/Data/FingerTree.purs
+++ b/src/Data/FingerTree.purs
@@ -218,10 +218,7 @@ instance traversableFingerTree :: Traversable (FingerTree v) where
            <*> (defer <$> kl)
            <*> traverse f sf
     where
-    l :: m (FingerTree v (Node v a))
     l = traverse (traverse f) (force m)
-
-    kl :: m (Unit -> FingerTree v (Node v a))
     kl = const <$> l
 
   sequence = traverse id


### PR DESCRIPTION
If they are really necessary (as documentation), we can just add some foralls