### PR TITLE
Purescript 0.9.3 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,22 +22,37 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-lazy": "^0.4.0",
-    "purescript-arrays": "^0.4.0",
-    "purescript-maybe": "^0.3.1",
-    "purescript-tuples": "^0.4.0",
-    "purescript-monoid": "^0.3.0",
-    "purescript-foldable-traversable": "^0.4.0",
-    "purescript-unfoldable": "^0.4.0",
-    "purescript-control": "^0.3.0",
-    "purescript-identity": "^0.4.0",
-    "purescript-profunctor": "^0.3.0",
-    "purescript-unsafe-coerce": "^0.1.0",
-    "purescript-exceptions": "^0.3.1"
+    "purescript-lazy": "^1.0.0",
+    "purescript-arrays": "^1.0.0",
+    "purescript-maybe": "^1.0.0",
+    "purescript-tuples": "^1.0.0",
+    "purescript-monoid": "^1.0.0",
+    "purescript-foldable-traversable": "^1.0.0",
+    "purescript-unfoldable": "^1.0.0",
+    "purescript-control": "^1.0.0",
+    "purescript-identity": "^1.0.0",
+    "purescript-profunctor": "^1.0.0",
+    "purescript-unsafe-coerce": "^1.0.0",
+    "purescript-exceptions": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^0.12.0",
-    "purescript-benchotron": "^3.0.3",
-    "purescript-quickcheck-laws": "~0.1.0"
+    "purescript-quickcheck": "^1.0.0",
+    "purescript-benchotron": "^1.0.0",
+    "purescript-quickcheck-laws": "^1.0.0"
+  },
+  "resolutions": {
+    "purescript-tuples": "^1.0.0",
+    "purescript-monoid": "^1.0.0",
+    "purescript-maybe": "^1.0.0",
+    "purescript-arrays": "1.0.0",
+    "purescript-identity": "^1.0.0",
+    "purescript-exceptions": "^1.0.0",
+    "purescript-foldable-traversable": "^1.0.0",
+    "purescript-unfoldable": "^1.0.0",
+    "purescript-control": "^1.0.0",
+    "purescript-profunctor": "^1.0.0",
+    "purescript-either": "^1.0.0",
+    "purescript-strings": "^1.0.0",
+    "purescript-integers": "^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,36 +23,21 @@
   ],
   "dependencies": {
     "purescript-lazy": "^1.0.0",
-    "purescript-arrays": "^1.0.0",
+    "purescript-arrays": "^1.1.0",
     "purescript-maybe": "^1.0.0",
     "purescript-tuples": "^1.0.0",
     "purescript-monoid": "^1.0.0",
     "purescript-foldable-traversable": "^1.0.0",
     "purescript-unfoldable": "^1.0.0",
     "purescript-control": "^1.0.0",
-    "purescript-identity": "^1.0.0",
+    "purescript-identity": "^1.1.0",
     "purescript-profunctor": "^1.0.0",
     "purescript-unsafe-coerce": "^1.0.0",
     "purescript-exceptions": "^1.0.0"
   },
   "devDependencies": {
     "purescript-quickcheck": "^1.0.0",
-    "purescript-benchotron": "^1.0.0",
+    "purescript-benchotron": "^4.0.0",
     "purescript-quickcheck-laws": "^1.0.0"
-  },
-  "resolutions": {
-    "purescript-tuples": "^1.0.0",
-    "purescript-monoid": "^1.0.0",
-    "purescript-maybe": "^1.0.0",
-    "purescript-arrays": "1.0.0",
-    "purescript-identity": "^1.0.0",
-    "purescript-exceptions": "^1.0.0",
-    "purescript-foldable-traversable": "^1.0.0",
-    "purescript-unfoldable": "^1.0.0",
-    "purescript-control": "^1.0.0",
-    "purescript-profunctor": "^1.0.0",
-    "purescript-either": "^1.0.0",
-    "purescript-strings": "^1.0.0",
-    "purescript-integers": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "devDependencies": {
-    "pulp": "^7.0.0",
-    "benchmark": "~1.0.0"
+    "pulp": "^9.0.1",
+    "benchmark": "~2.1.1"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/src/Data/FingerTree.purs
+++ b/src/Data/FingerTree.purs
@@ -153,8 +153,8 @@ instance showFingerTree :: (Show v, Show a) => Show (FingerTree v a) where
 instance semigroupFingerTree :: (Monoid v, Measured a v) => Semigroup (FingerTree v a) where
   append = append
 
--- We don't implement an Eq instance becAPse we don't want to make assumptions
--- about the meaning of the data, and becAPse we expect actual uses of
+-- We don't implement an Eq instance because we don't want to make assumptions
+-- about the meaning of the data, and because we expect actual uses of
 -- FingerTrees to use newtypes, so we provide this function instead to help
 -- with defining Ord instances.
 eqFingerTree :: forall a v. (Monoid v, Measured a v, Eq a) =>
@@ -173,8 +173,8 @@ eqFingerTree xs ys =
          else
            false
 
--- We don't implement an Ord instance becAPse we can't implement a good Eq
--- instance, and becAPse we expect actual uses of FingerTrees to use newtypes,
+-- We don't implement an Ord instance because we can't implement a good Eq
+-- instance, and because we expect actual uses of FingerTrees to use newtypes,
 -- so we provide this function instead to help with defining Ord instances.
 compareFingerTree :: forall a v. (Monoid v, Measured a v, Ord a) =>
   FingerTree v a -> FingerTree v a -> Ordering
@@ -201,12 +201,12 @@ instance foldableFingerTree :: Foldable (FingerTree v) where
   foldr f z (Deep _ pr m sf) = flipFoldr' pr (deepFlipFoldr (force m) (flipFoldr sf z))
     where
     flipFoldr = flip (foldr f)
---    infix 2 flipFoldr as `f`<
+--    infix 2 flipFoldr as -<<
     -- this is a hack to get type inference to work
     flipFoldr' = flip (foldr f)
 --    infix 2 flipFoldr' as +<<
     deepFlipFoldr = flip (foldr (flip (foldr f)))
---    infix 2 deepFlipFoldr as `f`<<
+--    infix 2 deepFlipFoldr as -<<
 
 
   foldl f z Empty            = z
@@ -214,9 +214,9 @@ instance foldableFingerTree :: Foldable (FingerTree v) where
   foldl f z (Deep _ pr m sf) = leftFold (deepLeftFold (leftFold z pr) (force m)) sf
     where
     leftFold = foldl f
---    infix 2 leftFold as >`f`
+--    infix 2 leftFold as >>-
     deepLeftFold = foldl (foldl f)
---    infix 2 deepLeftFold as >>`f`
+--    infix 2 deepLeftFold as >>-
 
   foldMap f xs = foldr (\x acc -> f x <> acc) mempty xs
 

--- a/src/Data/Sequence.purs
+++ b/src/Data/Sequence.purs
@@ -66,6 +66,7 @@ import Prelude  (class Ord, class Functor, class Monad, class Bind, class Applic
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
 import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 import Data.Foldable (class Foldable, foldl, foldMap, foldr)
 import Data.Lazy (Lazy(), force)
@@ -145,6 +146,8 @@ instance plusSeq :: Plus Seq where
   empty = empty
 
 instance alternativeSeq :: Alternative Seq
+
+instance monadZeroSeq :: MonadZero Seq
 
 instance monadPlusSeq :: MonadPlus Seq
 

--- a/src/Data/Sequence/Internal.purs
+++ b/src/Data/Sequence/Internal.purs
@@ -1,6 +1,5 @@
 module Data.Sequence.Internal
-  ( (!)
-  , (<$$>), mapmap
+  ( (<$$>), mapmap
   , (<$$$>), mapmapmap
   , strJoin
   , class Measured
@@ -16,7 +15,6 @@ module Data.Sequence.Internal
 
 import Prelude (class Ord, class Semigroup, class Show, class Eq, class Functor, Ordering(GT, LT), compare, show, (<>), (==), map, (<<<), (<$>))
 
-import Data.Array.Unsafe (unsafeIndex)
 import Data.Foldable (class Foldable, foldl, intercalate)
 import Data.Lazy (Lazy(), force)
 import Data.Monoid (class Monoid, mempty)
@@ -26,8 +24,6 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -----------------------
 -- Various utilities
-infix 2 unsafeIndex as !
-
 mapmap :: forall f g a b. (Functor f, Functor g) =>
   (a -> b) -> f (g a) -> f (g b)
 mapmap = (<$>) <<< (<$>)

--- a/src/Data/Sequence/NonEmpty.purs
+++ b/src/Data/Sequence/NonEmpty.purs
@@ -49,11 +49,11 @@ import Prelude (class Semigroup, class Monad, class Bind, class Applicative, cla
 
 import Control.Alt (class Alt)
 import Data.Foldable (class Foldable, foldl, foldMap, foldr)
-import Data.Maybe (Maybe(Just, Nothing), maybe)
-import Data.Maybe.Unsafe (fromJust)
+import Data.Maybe (Maybe(Just, Nothing), maybe, fromJust)
 import Data.Traversable (class Traversable, sequence, traverse)
 import Data.Tuple (Tuple(Tuple), fst, uncurry)
 import Data.Unfoldable (class Unfoldable)
+import Partial.Unsafe (unsafePartial)
 
 import Data.Sequence as S
 
@@ -170,7 +170,7 @@ replace x = adjust (const x)
 toUnfoldable :: forall f a. (Functor f, Unfoldable f) => Seq a -> f a
 toUnfoldable = S.toUnfoldable <<< toPlain
 
-fromPlainUnsafe :: forall a. S.Seq a -> Seq a
+fromPlainUnsafe :: forall a. Partial => S.Seq a -> Seq a
 fromPlainUnsafe = S.uncons >>> fromJust >>> uncurry Seq
 
 instance showSeq :: (Show a) => Show (Seq a) where
@@ -189,13 +189,13 @@ instance functorSeq :: Functor Seq where
   map f (Seq x xs) = Seq (f x) (f <$> xs)
 
 instance applySeq :: Apply Seq where
-  apply fs xs = fromPlainUnsafe (toPlain fs <*> toPlain xs)
+  apply fs xs = unsafePartial fromPlainUnsafe (toPlain fs <*> toPlain xs)
 
 instance applicativeSeq :: Applicative Seq where
   pure x = Seq x S.empty
 
 instance bindSeq :: Bind Seq where
-  bind xs f = fromPlainUnsafe (toPlain xs >>= (toPlain <<< f))
+  bind xs f = unsafePartial fromPlainUnsafe (toPlain xs >>= (toPlain <<< f))
 
 instance monadSeq :: Monad Seq
 
@@ -211,5 +211,5 @@ instance foldableSeq :: Foldable Seq where
   foldMap f = toPlain >>> foldMap f
 
 instance traversableSeq :: Traversable Seq where
-  sequence   = toPlain >>> sequence   >>> map fromPlainUnsafe
-  traverse f = toPlain >>> traverse f >>> map fromPlainUnsafe
+  sequence   = toPlain >>> sequence   >>> map (unsafePartial fromPlainUnsafe)
+  traverse f = toPlain >>> traverse f >>> map (unsafePartial fromPlainUnsafe)

--- a/test/Data/Sequence.purs
+++ b/test/Data/Sequence.purs
@@ -129,14 +129,14 @@ sequenceTests = do
   quickCheck $ \(ArbSeq seq) idx ->
     let seq' = const 0 <$> S.cons 0 seq
         idx' = integerBetween 0 (S.length seq') idx
-        result = sum (S.adjust (+1) idx' seq')
+        result = sum (S.adjust (_+1) idx' seq')
     in  result == 1 <?> "seq': " <> show seq' <> ", result: " <> show result
 
   log "Test adjust modifies at the correct index"
   quickCheck $ \(ArbSeq seq) idx ->
     let seq' = const "hello" <$> S.cons 0 seq
         idx' = integerBetween 0 (S.length seq') idx
-        result = S.index idx' (S.adjust (<> ", world") idx' seq')
+        result = S.index idx' (S.adjust (_ <> ", world") idx' seq')
     in  (result == Just "hello, world")
           <?> "seq': " <> show seq' <> ", result: " <> show result
 

--- a/test/Data/Sequence/NonEmpty.purs
+++ b/test/Data/Sequence/NonEmpty.purs
@@ -118,7 +118,7 @@ nonEmptySequenceTests = do
   quickCheck $ \(ArbNESeq seq) idx ->
     let seq' = const 0 <$> (seq :: NonEmpty.Seq Unit)
         idx' = integerBetween 0 (NonEmpty.length seq') idx
-        result = sum (NonEmpty.adjust (+1) idx' seq')
+        result = sum (NonEmpty.adjust (_+1) idx' seq')
     in  result == 1 <?> "seq': " <> show seq' <> ", result: " <> show result
 
   log "Test take"

--- a/test/Data/Sequence/Ordered.purs
+++ b/test/Data/Sequence/Ordered.purs
@@ -103,7 +103,7 @@ orderedSequenceTests = do
     let seq' = OrdSeq.insert 1 seq -- ensure nonempty
     in case OrdSeq.popLeast seq' of
          Nothing -> false
-         Just (Tuple x seq'') -> all (>= x) seq''
+         Just (Tuple x seq'') -> all (_ >= x) seq''
 
   log "Test greatest"
   quickCheck $ \(ArbOSeq seq) ->
@@ -121,7 +121,7 @@ orderedSequenceTests = do
     let seq' = OrdSeq.insert 0 seq -- ensure nonempty
     in case OrdSeq.popGreatest seq' of
          Nothing -> false
-         Just (Tuple x seq'') -> all (<= x) seq''
+         Just (Tuple x seq'') -> all (_ <= x) seq''
 
   log "Test sort is the same as Data.Array.sort"
   quickCheck $ \array ->

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -12,6 +12,7 @@ import Control.Alt (class Alt, (<|>))
 import Control.Plus (class Plus, empty)
 import Control.Alternative (class Alternative)
 import Control.MonadPlus (class MonadPlus)
+import Control.MonadZero (class MonadZero)
 import Test.QuickCheck (class Testable, QC, (<?>), quickCheck', Result)
 import Test.QuickCheck.Arbitrary (class Arbitrary, arbitrary)
 import Test.QuickCheck.Gen (Gen())
@@ -68,6 +69,8 @@ instance plusArbSeq :: Plus ArbSeq where
 instance alternativeArbseq :: Alternative ArbSeq
 
 instance monadPlusArbSeq :: MonadPlus ArbSeq
+
+instance monadZeroArbSeq :: MonadZero ArbSeq
 
 instance arbitraryArbSeq :: (Arbitrary a) => Arbitrary (ArbSeq a) where
   arbitrary = (ArbSeq <<< S.fromFoldable) <$> (arbitrary :: Gen (Array a))


### PR DESCRIPTION
This is based on the fork by @sardonicpresence (https://github.com/sardonicpresence/purescript-sequences). There are three minor changes:
- tests fixed
- updated dependencies
- typos fixed

I know there's another effort under way (PR #23) which, as far as I understand, aims to eliminate `unsafePartial` with proper `Partial` constraints propagation. However it seems that the work there stalled, and it would be great to have a working implementation of sequences for psc 0.9.x meanwhile :)

To sum up:
- **the good**: tests pass (at least on my machine)
- **the bad**: `unsafePartial` is used
