### PR TITLE
Upgrade to PS 0.15.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,22 +23,24 @@
   ],
   "dependencies": {
     "purescript-arrays": "^v6.0.0",
-    "purescript-assert": "^v5.0.0",
-    "purescript-console": "^v5.0.0",
-    "purescript-effect": "^v3.0.0",
+    "purescript-control": "^v6.0.0",
+    "purescript-foldable-traversable": "^v6.0.0",
     "purescript-lazy": "^v5.0.0",
     "purescript-maybe": "^v5.0.0",
     "purescript-newtype": "^v4.0.0",
-    "purescript-nonempty": "^v6.0.0",
     "purescript-partial": "^v3.0.0",
     "purescript-prelude": "^v5.0.0",
     "purescript-profunctor": "^v5.0.0",
-    "purescript-psci-support": "^v5.0.0",
     "purescript-tuples": "^v6.0.0",
     "purescript-unfoldable": "^v5.0.0",
     "purescript-unsafe-coerce": "^v5.0.0"
   },
   "devDependencies": {
+    "purescript-assert": "^v5.0.0",
+    "purescript-console": "^v5.0.0",
+    "purescript-effect": "^v3.0.0",
+    "purescript-nonempty": "^v6.0.0",
+    "purescript-psci-support": "^v5.0.0",
     "purescript-quickcheck": "^7.0.0",
     "purescript-quickcheck-laws": "^6.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -22,18 +22,18 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-arrays": "^v6.0.0",
+    "purescript-arrays": "^v7.0.0",
     "purescript-control": "^v6.0.0",
     "purescript-foldable-traversable": "^v6.0.0",
-    "purescript-lazy": "^v5.0.0",
-    "purescript-maybe": "^v5.0.0",
-    "purescript-newtype": "^v4.0.0",
-    "purescript-partial": "^v3.0.0",
-    "purescript-prelude": "^v5.0.0",
-    "purescript-profunctor": "^v5.0.0",
-    "purescript-tuples": "^v6.0.0",
-    "purescript-unfoldable": "^v5.0.0",
-    "purescript-unsafe-coerce": "^v5.0.0"
+    "purescript-lazy": "^v6.0.0",
+    "purescript-maybe": "^v6.0.0",
+    "purescript-newtype": "^v5.0.0",
+    "purescript-partial": "^v4.0.0",
+    "purescript-prelude": "^v6.0.1",
+    "purescript-profunctor": "^v6.0.0",
+    "purescript-tuples": "^v7.0.0",
+    "purescript-unfoldable": "^v6.0.0",
+    "purescript-unsafe-coerce": "^v6.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^v5.0.0",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "purescript-assert": "^v6.0.0",
     "purescript-console": "^v6.0.0",
     "purescript-effect": "^v4.0.0",
-    "purescript-psci-support": "^v5.0.0",
+    "purescript-psci-support": "^v6.0.0",
     "purescript-quickcheck": "^8.0.1",
     "purescript-quickcheck-laws": "^7.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -36,12 +36,11 @@
     "purescript-unsafe-coerce": "^v6.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "^v5.0.0",
-    "purescript-console": "^v5.0.0",
-    "purescript-effect": "^v3.0.0",
-    "purescript-nonempty": "^v6.0.0",
+    "purescript-assert": "^v6.0.0",
+    "purescript-console": "^v6.0.0",
+    "purescript-effect": "^v4.0.0",
     "purescript-psci-support": "^v5.0.0",
-    "purescript-quickcheck": "^7.0.0",
-    "purescript-quickcheck-laws": "^6.0.0"
+    "purescript-quickcheck": "^8.0.1",
+    "purescript-quickcheck-laws": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "bench": "pulp build -I benchmarks --main Benchmark.Main -O --to output/benchmarks.js && (echo '*' | node output/benchmarks.js)",
     "build": "pulp build",
     "test": "pulp test"
+  },
+  "dependencies": {
+    "spago": "^0.20.9"
   }
 }

--- a/src/Data/Sequence.purs
+++ b/src/Data/Sequence.purs
@@ -1,4 +1,3 @@
-
 -- | This module provides a sequence data type, intended for the same sort of
 -- | tasks as an Array would be in JavaScript, except with better asymptotic
 -- | complexity for many operations.
@@ -66,7 +65,6 @@ import Prelude hiding (append, map)
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
 import Control.MonadPlus (class MonadPlus)
-import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus)
 import Data.Foldable (class Foldable, foldl, foldMap, foldr)
 import Data.Lazy (Lazy(), force)
@@ -166,8 +164,6 @@ instance plusSeq :: Plus Seq where
 instance alternativeSeq :: Alternative Seq
 
 instance monadPlusSeq :: MonadPlus Seq
-
-instance monadZeroSeq :: MonadZero Seq
 
 -- | A sequence with no elements.
 empty :: forall a. Seq a

--- a/test/Data/Sequence.purs
+++ b/test/Data/Sequence.purs
@@ -12,7 +12,7 @@ import Data.Unfoldable (replicate, unfoldr, replicate1, unfoldr1)
 
 import Test.Assert (assert)
 import Test.QuickCheck ((<?>), (===), quickCheck)
-import Type.Proxy (Proxy(Proxy), Proxy2(Proxy2))
+import Type.Proxy (Proxy(..))
 import Test.QuickCheck.Laws (A())
 import Test.QuickCheck.Laws.Data.Eq (checkEq)
 import Test.QuickCheck.Laws.Data.Ord (checkOrd)
@@ -37,8 +37,8 @@ arr = S.toUnfoldable
 prx :: Proxy (ArbSeq A)
 prx = Proxy
 
-prx2 :: Proxy2 ArbSeq
-prx2 = Proxy2
+prx2 :: Proxy ArbSeq
+prx2 = Proxy
 
 sequenceTests :: Effect Unit
 sequenceTests = do

--- a/test/Data/Sequence/NonEmpty.purs
+++ b/test/Data/Sequence/NonEmpty.purs
@@ -25,7 +25,7 @@ import Test.QuickCheck.Laws.Data.Functor (checkFunctor)
 import Test.QuickCheck.Laws.Data.Ord (checkOrd)
 import Test.QuickCheck.Laws.Data.Semigroup (checkSemigroup)
 import Tests.Utils (ArbNESeq(..), err, abs, integerBetween, foldableSize)
-import Type.Proxy (Proxy(..), Proxy2(..))
+import Type.Proxy (Proxy(..))
 
 arr :: forall a. NonEmpty.Seq a -> Array a
 arr = NonEmpty.toUnfoldable
@@ -33,8 +33,8 @@ arr = NonEmpty.toUnfoldable
 prx :: Proxy (ArbNESeq A)
 prx = Proxy
 
-prx2 :: Proxy2 ArbNESeq
-prx2 = Proxy2
+prx2 :: Proxy ArbNESeq
+prx2 = Proxy
 
 nonEmptySequenceTests :: Effect Unit
 nonEmptySequenceTests = do

--- a/test/Utils.purs
+++ b/test/Utils.purs
@@ -5,7 +5,6 @@ import Prelude
 import Control.Alt (class Alt, (<|>))
 import Control.Alternative (class Alternative)
 import Control.MonadPlus (class MonadPlus)
-import Control.MonadZero (class MonadZero)
 import Control.Plus (class Plus, empty)
 import Data.Array as A
 import Data.Foldable (class Foldable, intercalate, foldr, foldMap)
@@ -70,8 +69,6 @@ instance plusArbSeq :: Plus ArbSeq where
 instance alternativeArbseq :: Alternative ArbSeq
 
 instance monadPlusArbSeq :: MonadPlus ArbSeq
-
-instance monadZeroArbSeq :: MonadZero ArbSeq
 
 instance arbitraryArbSeq :: (Arbitrary a) => Arbitrary (ArbSeq a) where
   arbitrary = (ArbSeq <<< S.fromFoldable) <$> (arbitrary :: Gen (Array a))


### PR DESCRIPTION
This removes the deprecated `Control.MonadZero` monad.

I also used spago internally and found out unnecessary deps and some required one (`control`, `foldable-traversable`) so I added them to the `bower.json` file.